### PR TITLE
Set the wifi region before starting network

### DIFF
--- a/net-wireless/rpi3-wifi-regdom/files/init.d_rpi3-wifi-regdom-1
+++ b/net-wireless/rpi3-wifi-regdom/files/init.d_rpi3-wifi-regdom-1
@@ -8,7 +8,7 @@
 description="Sets up WiFi regulatory domain on the RPi3"
 
 depend() {
-	need net
+	before net
 }
 
 start() {


### PR DESCRIPTION
If the region isn't set early, the wifi may fail to connect because the current rules don't let it see the network.
(For example, American 5GHz wifi)