### PR TITLE
Remove oddly specific profile wide useflags

### DIFF
--- a/profiles/targets/genpi64/package.use/apache
+++ b/profiles/targets/genpi64/package.use/apache
@@ -1,8 +1,0 @@
-# turn on necessary modules for jitsi meet
->=www-servers/apache-2.4.41 apache2_modules_access_compat apache2_modules_alias 
->=www-servers/apache-2.4.41 apache2_modules_authz_core apache2_modules_authz_host
->=www-servers/apache-2.4.41 apache2_modules_dir apache2_modules_headers
->=www-servers/apache-2.4.41 apache2_modules_include apache2_modules_mime
->=www-servers/apache-2.4.41 apache2_modules_proxy apache2_modules_proxy_http
->=www-servers/apache-2.4.41 apache2_modules_rewrite apache2_modules_socache_shmcb
->=www-servers/apache-2.4.41 apache2_modules_unixd

--- a/profiles/targets/genpi64/package.use/nginx
+++ b/profiles/targets/genpi64/package.use/nginx
@@ -1,4 +1,0 @@
-# add threading support
-www-servers/nginx threads
-# for Jitsi with turnserver mux on port 443
->=www-servers/nginx-1.18.0 nginx_modules_stream_ssl_preread nginx_modules_stream_map


### PR DESCRIPTION
These use-flags are really oddly specific, and don't belong in a profile. Users who want jitsi support can easily enable it themselves, and if we want to provide binpkgs for this, it can be done at a different stage of the build process.