### PR TITLE
Use repo scoping syntax instead of relative path

### DIFF
--- a/profiles/default/linux/arm64/17.0/genpi64/desktop/systemd/parent
+++ b/profiles/default/linux/arm64/17.0/genpi64/desktop/systemd/parent
@@ -1,4 +1,4 @@
 gentoo:default/linux/arm64/17.0/desktop
-../../../../../../targets/genpi64
-../../../../../../targets/genpi64/desktop
+genpi64:targets/genpi64
+genpi64:targets/genpi64/desktop
 gentoo:targets/systemd

--- a/profiles/default/linux/arm64/17.0/genpi64/systemd/parent
+++ b/profiles/default/linux/arm64/17.0/genpi64/systemd/parent
@@ -1,3 +1,3 @@
 gentoo:default/linux/arm64/17.0
-../../../../../targets/genpi64
+genpi64:targets/genpi64
 gentoo:targets/systemd


### PR DESCRIPTION
I broke relative paths for the systemd profile when I re-arranged things. Oops.

This uses the reponame:path syntax instead of a full relative path.

Should work right? If not, what is the genpi64 profile missing to let this work?