### PR TITLE
Fix build libsdl2

### DIFF
--- a/media-libs/libsdl2/libsdl2-2.0.14-r1.ebuild
+++ b/media-libs/libsdl2/libsdl2-2.0.14-r1.ebuild
@@ -115,6 +115,7 @@ multilib_src_configure() {
 
 	# libsdl2-2.0.14 build regression. Please check if still needed
 	append-flags -D__LINUX__
+	append-ldflags -lvchostif
 
 	if use ibus; then
 		local -x IBUS_CFLAGS="-I${ESYSROOT}/usr/include/ibus-1.0 -I${ESYSROOT}/usr/include/glib-2.0 -I${ESYSROOT}/usr/$(get_libdir)/glib-2.0/include"

--- a/profiles/targets/genpi64/package.mask/sdl2
+++ b/profiles/targets/genpi64/package.mask/sdl2
@@ -1,2 +1,2 @@
 <media-libs/libsdl2-2.0.14-r1
-media-libs/libsdl2::gentoo
+media-libs/libsdl2:gentoo


### PR DESCRIPTION
Added a fix for building libsdl2. The following bugs have been fixed:
1:
```
--- Invalid atom in /var/db/repos/genpi64/profiles/targets/genpi64/package.mask/sdl2: media-libs/libsdl2::gentoo
```
2:
```
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x104): undefined reference to `vc_dispmanx_element_change_attributes'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x118): undefined reference to `vc_dispmanx_update_submit'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: build/.libs/SDL_rpimouse.o: in function `RPI_FreeCursor':
SDL_rpimouse.c:(.text+0x1d4): undefined reference to `vc_dispmanx_update_start'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x1e0): undefined reference to `vc_dispmanx_element_remove'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x1e8): undefined reference to `vc_dispmanx_update_submit_sync'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x1f8): undefined reference to `vc_dispmanx_resource_delete'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: build/.libs/SDL_rpimouse.o: in function `RPI_ShowCursor':
SDL_rpimouse.c:(.text+0x2f0): undefined reference to `vc_dispmanx_rect_set'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x310): undefined reference to `vc_dispmanx_rect_set'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x318): undefined reference to `vc_dispmanx_update_start'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x360): undefined reference to `vc_dispmanx_element_add'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x370): undefined reference to `vc_dispmanx_update_submit_sync'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x384): undefined reference to `vc_dispmanx_update_start'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x390): undefined reference to `vc_dispmanx_element_remove'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x398): undefined reference to `vc_dispmanx_update_submit_sync'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: build/.libs/SDL_rpimouse.o: in function `RPI_CreateCursor':
SDL_rpimouse.c:(.text+0x44c): undefined reference to `vc_dispmanx_resource_create'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x46c): undefined reference to `vc_dispmanx_rect_set'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x484): undefined reference to `vc_dispmanx_resource_write_data'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: build/.libs/SDL_rpimouse.o: in function `RPI_MoveCursor':
SDL_rpimouse.c:(.text+0x560): undefined reference to `vc_dispmanx_update_start'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x5c8): undefined reference to `vc_dispmanx_element_change_attributes'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpimouse.c:(.text+0x5dc): undefined reference to `vc_dispmanx_update_submit'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: build/.libs/SDL_rpivideo.o: in function `AddDispManXDisplay':
SDL_rpivideo.c:(.text+0x250): undefined reference to `vc_dispmanx_display_open'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpivideo.c:(.text+0x280): undefined reference to `vc_dispmanx_display_get_info'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpivideo.c:(.text+0x2b0): undefined reference to `vc_tv_get_display_state'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpivideo.c:(.text+0x32c): undefined reference to `vc_dispmanx_display_close'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpivideo.c:(.text+0x340): undefined reference to `vc_tv_hdmi_get_property'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpivideo.c:(.text+0x364): undefined reference to `vc_dispmanx_display_close'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: build/.libs/SDL_rpivideo.o: in function `RPI_CreateWindow':
SDL_rpivideo.c:(.text+0x4e0): undefined reference to `vc_dispmanx_update_start'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpivideo.c:(.text+0x50c): undefined reference to `vc_dispmanx_element_add'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpivideo.c:(.text+0x52c): undefined reference to `vc_dispmanx_update_submit_sync'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: SDL_rpivideo.c:(.text+0x5d0): undefined reference to `vc_dispmanx_vsync_callback'
/usr/lib/gcc/aarch64-unknown-linux-gnu/10.2.0/../../../../aarch64-unknown-linux-gnu/bin/ld: build/.libs/SDL_rpivideo.o: in function `RPI_DestroyWindow':
SDL_rpivideo.c:(.text+0x6d8): undefined reference to `vc_dispmanx_vsync_callback'
collect2: error: ld returned 1 exit status
make: *** [Makefile:154: build/libSDL2.la] Error 1
```