### PR TITLE
Fix systemd desktop profile

### DIFF
--- a/profiles/default/linux/arm64/17.0/genpi64/desktop/systemd/parent
+++ b/profiles/default/linux/arm64/17.0/genpi64/desktop/systemd/parent
@@ -1,4 +1,4 @@
 gentoo:default/linux/arm64/17.0/desktop
 genpi64:targets/genpi64
-genpi64:targets/genpi64/desktop
+genpi64:targets/genpi64desktop
 gentoo:targets/systemd


### PR DESCRIPTION
At some point the location of the desktop profile was changed. This fixes the parent relationship.
Problem detected by repoman.