### PR TITLE
Fix auto expand apps using a helper script. 

### DIFF
--- a/sys-apps/rpi-onetime-startup/files/autoexpand_root.service-5
+++ b/sys-apps/rpi-onetime-startup/files/autoexpand_root.service-5
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run GenPi64 startup script to auto expand root partition
+ConditionFirstBoot=yes
+ConditionPathExists=!/boot/dont_autoexpand_root
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/boot/autoexpand_root.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/sys-apps/rpi-onetime-startup/files/autoexpand_root.sh-5
+++ b/sys-apps/rpi-onetime-startup/files/autoexpand_root.sh-5
@@ -1,0 +1,96 @@
+#!/bin/sh
+#
+# Automatically attempt to extend root partition (calculated from
+# the filesystem mounted at '/') to fill remaining free space on the device
+#
+# Checks for a sentinel file "dont_autoexpand_root" on /boot
+# and will proceed only if not found.
+
+SENTINEL="/boot/dont_autoexpand_root"
+if [ -f "${SENTINEL}" ]; then
+	# sentinel found, service should really be disabled
+	echo "Sentinel file detected; consider deleting ${SVCNAME} from boot runlevel"
+	return 0
+fi
+
+# Find the partition mounted as / according to the kernel
+ROOTPART="$(awk '/\s\/\s/{print $1}' /proc/mounts)"
+# Find the root partitions filesystem type
+ROOTFS="$(awk '/\s\/\s/{print $3}' /proc/mounts)"
+# Discard the partition number to find the underlying drive
+ROOTDRIVE="$(sed 's/[0-9]*$//;s/\([0-9]\)p$/\1/' <<<"${ROOTPART}")"
+# Get the partition number too
+PNUM="$(egrep -o "[0-9]+$" <<<"${ROOTPART}")"
+
+# Ensure we get some kind of data from the above
+if [[ -z "${ROOTPART}" || -z "${ROOTFS}" || -z "${ROOTDRIVE}" || -z "${PNUM}" ]]; then
+	echo "Unable to determine root path components"
+	return 1
+fi
+
+# first boot, need to resize root partition to fill disk
+# then, since this is /, need to reboot to get kernel to see it
+# after which its ext4 filesystem can be resized online
+
+echo ""
+echo "*******************************************************************"
+echo "* Auto resizing root partition to fill block device - please wait *"
+echo "*******************************************************************"
+echo ""
+
+touch "${SENTINEL}"
+if ! [ -f "${SENTINEL}" ]; then
+	# might mean an ro filesystem, and we don't want an
+	# infinite loop
+	echo "Failed to delete sentinel file '${SENTINEL}'"
+	return 1
+fi
+
+# turn off swapfiles, for safety
+swapoff -a
+
+# sync filesystems before we begin, to minimize any damage if things go wrong
+if ! sync &>/dev/null; then
+	echo "Failed to sync to disk"
+	return 1
+fi
+
+# begin by resizing the root partition
+if ! sfdisk --no-reread --no-tell-kernel -N ${PNUM} <<<", +" "${ROOTDRIVE}" &>/dev/null; then
+	echo "Failed to resize root partition"
+	return 1
+fi
+
+# Tell the kernel about the change. Seperate for sake of logging
+if ! partprobe "${ROOTPART}" &>/dev/null; then
+	echo "Failed to read root partition change"
+	return 1
+fi
+
+# Do an online resize of the root partition file system
+if [ "${ROOTFS}" = "btrfs" ]; then
+	if ! btrfs filesystem resize max "/" &>/dev/null; then
+		echo "Failed to resize root filesystem"
+		return 1
+	fi
+else
+	if ! resize2fs -f "${ROOTPART}" &>/dev/null; then
+		echo "Failed to resize root filesystem"
+		return 1
+	fi
+fi
+
+# Flush everything to disk
+if ! sync &>/dev/null; then
+	echo "Failed to sync to disk"
+	return 1
+fi
+
+# Swap is OK to use again
+swapon -a
+
+echo ""
+echo "*******************************************************************"
+echo "*  Resize completed                                               *"
+echo "*******************************************************************"
+echo ""

--- a/sys-apps/rpi-onetime-startup/rpi-onetime-startup-1.0-r5.ebuild
+++ b/sys-apps/rpi-onetime-startup/rpi-onetime-startup-1.0-r5.ebuild
@@ -1,0 +1,46 @@
+# Copyright (c) 2019 sakaki <sakaki@deciban.com>
+# License: GPL v2 or GPL v3+
+# NO WARRANTY
+EAPI=6
+
+inherit systemd
+
+KEYWORDS="~arm arm64"
+
+DESCRIPTION="Run one-time startup script, if present"
+HOMEPAGE="https://github.com/GenPi64/gentoo-on-rpi-64bit"
+SRC_URI=""
+LICENSE="GPL-3+"
+SLOT="0"
+IUSE="-systemd"
+RESTRICT="mirror"
+
+# required by Portage, as we have no SRC_URI...
+S="${WORKDIR}"
+
+DEPEND=""
+RDEPEND="${DEPEND}
+	systemd?  ( >=sys-apps/systemd-242-r6 )
+	!systemd? ( >=sys-apps/openrc-0.41 )
+	>=app-shells/bash-4.0"
+
+src_install() {
+	newinitd "${FILESDIR}/init.d_${PN}-2" "${PN}"
+	exeinto /boot
+	newexe "${FILESDIR}/startup.sh-2" "startup.sh"
+	newenvd "${FILESDIR}"/config_protect-1 99${PN}
+	newexe "${FILESDIR}/autoexpand_root.sh-5" "autoexpand_root.sh"
+	systemd_newunit "${FILESDIR}/autoexpand_root.service-5" "autoexpand_root.service"
+}
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		rc-update add "${PN}" default
+		elog "The ${PN} service has been added to your default runlevel."
+	fi
+	if use systemd; then
+		ewarn "You are running with the systemd USE flag set!"
+		ewarn "However, this package does not yet formally support systemd, so"
+		ewarn "you are on your own to get things working ><"
+	fi
+}

--- a/sys-apps/rpi3-init-scripts/files/init.d_autoexpand_root-5
+++ b/sys-apps/rpi3-init-scripts/files/init.d_autoexpand_root-5
@@ -1,0 +1,23 @@
+#!/sbin/openrc-run
+#
+# Automatically attempt to extend root partition to fill remaining free space on the device
+#
+# Checks for a sentinel file "dont_autoexpand_root" on /boot
+# and will proceed only if not found.
+#
+# Copyright (c) 2017 sakaki <sakaki@deciban.com>
+# License: GPL v2 or GPL 3.0+
+# NO WARRANTY
+
+description="Auto-expands root partition (for GenPi64)"
+
+depend() {
+	need localmount
+	after modules sysctl root
+}
+
+start() {
+	ebegin "Starting ${SVCNAME}"
+	/boot/autoexpand_root.sh
+	eend $?
+}

--- a/sys-apps/rpi3-init-scripts/rpi3-init-scripts-1.1.5-r5.ebuild
+++ b/sys-apps/rpi3-init-scripts/rpi3-init-scripts-1.1.5-r5.ebuild
@@ -1,0 +1,59 @@
+# Copyright (c) 2017 sakaki <sakaki@deciban.com>
+# License: GPL v2 or GPL v3+
+# NO WARRANTY
+
+EAPI=5
+
+KEYWORDS="~arm arm64"
+
+DESCRIPTION="Misc init scripts for the gentoo-on-rpi3-64bit image"
+HOMEPAGE="https://github.com/GenPi64/gentoo-on-rpi3-64bit"
+SRC_URI=""
+LICENSE="GPL-3+"
+SLOT="0"
+IUSE="-systemd +X"
+RESTRICT="mirror"
+AR_SVCNAME="autoexpand-root"
+
+# required by Portage, as we have no SRC_URI...
+S="${WORKDIR}"
+
+DEPEND=""
+RDEPEND="${DEPEND}
+	rpi-onetime-startup
+	X? ( >=x11-apps/xdm-1.1.12 )
+	systemd?  ( >=sys-apps/systemd-246.6 )
+	!systemd? ( >=sys-apps/openrc-0.42.1-r1 )
+	>=app-shells/bash-5.1_p4"
+
+src_install() {
+	newinitd "${FILESDIR}/init.d_autoexpand_root-5" "${AR_SVCNAME}"
+	insinto "/usr/share/X11/xorg.conf.d"
+	newins "${FILESDIR}/50-disable-Xv.conf-1" "50-disable-Xv.conf"
+	insinto "/etc/NetworkManager/conf.d"
+	newins "${FILESDIR}/50-hostname-mode-none.conf-1" "50-hostname-mode-none.conf"
+	insinto "/etc/sysctl.d"
+	newins "${FILESDIR}/35-low-memory-cache-settings.conf-1" "35-low-memory-cache-settings.conf"
+}
+
+pkg_postinst() {
+	if [[ -z ${REPLACING_VERSIONS} ]]; then
+		rc-update add "${AR_SVCNAME}" boot
+		elog "The first-boot root partition resizing service has been activated."
+		elog "This service will run so long as the sentinel file /boot/dont_autoexpand_root"
+		elog "Does not exist."
+		elog "To disable entirely, run:"
+		elog "  rc-update del ${AR_SVCNAME} boot"
+	fi
+	local OLDRULE="/etc/X11/xorg.conf.d/50-disable-Xv.conf"
+	if [ -f "${OLDRULE}" ]; then
+		elog "Removing old XVideo disable rule"
+		elog "New managed version is in /usr/share/X11/xorg.conf.d"
+		rm "${OLDRULE}"
+	fi
+	if use systemd; then
+		ewarn "You are running with the systemd USE flag set!"
+		ewarn "However, this package does not yet formally support systemd, so"
+		ewarn "you are on your own to get things working ><"
+	fi
+}


### PR DESCRIPTION
Remove password setting and service enabling code, which shouldn't be happening on firstboot in the first place. These tasks should be done in the image builder only.