### PR TITLE
Remove package.accept_keywords for packages that are either already s…

### DIFF
--- a/profiles/targets/genpi64/package.accept_keywords/ack
+++ b/profiles/targets/genpi64/package.accept_keywords/ack
@@ -1,3 +1,0 @@
-sys-apps/ack	* ~*
-# dependencies of sys-apps/ack
-dev-perl/File-Next	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/aide
+++ b/profiles/targets/genpi64/package.accept_keywords/aide
@@ -1,1 +1,0 @@
-app-forensics/aide * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/appstream-glib
+++ b/profiles/targets/genpi64/package.accept_keywords/appstream-glib
@@ -1,4 +1,0 @@
-dev-libs/appstream-glib	*
-# dependencies of appstream-glib
-dev-util/appdata-tools	*
-

--- a/profiles/targets/genpi64/package.accept_keywords/at
+++ b/profiles/targets/genpi64/package.accept_keywords/at
@@ -1,2 +1,0 @@
-# per andi4567, this is working on arm64
-sys-process/at * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/authbind
+++ b/profiles/targets/genpi64/package.accept_keywords/authbind
@@ -1,1 +1,0 @@
-app-admin/authbind * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/boinc
+++ b/profiles/targets/genpi64/package.accept_keywords/boinc
@@ -1,1 +1,0 @@
-sci-misc/boinc * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/chrony
+++ b/profiles/targets/genpi64/package.accept_keywords/chrony
@@ -1,1 +1,0 @@
-net-misc/chrony * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/coturn
+++ b/profiles/targets/genpi64/package.accept_keywords/coturn
@@ -1,1 +1,0 @@
-net-im/coturn * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/dav1d
+++ b/profiles/targets/genpi64/package.accept_keywords/dav1d
@@ -1,1 +1,0 @@
-media-libs/dav1d * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/dos2unix
+++ b/profiles/targets/genpi64/package.accept_keywords/dos2unix
@@ -1,1 +1,0 @@
-app-text/dos2unix	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/elogviewer
+++ b/profiles/targets/genpi64/package.accept_keywords/elogviewer
@@ -1,6 +1,0 @@
-app-portage/elogviewer * ~*
-# dependencies of app-portage/elogviewer
-dev-python/PyQt5	* ~*
-dev-python/sip	* ~*
-dev-vcs/mercurial	* ~*
-dev-qt/qtbluetooth	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/emacs
+++ b/profiles/targets/genpi64/package.accept_keywords/emacs
@@ -1,5 +1,0 @@
-virtual/emacs	* ~*
-# dependencies of virtual/emacs
-app-editors/emacs	* ~*
-app-eselect/eselect-emacs	* ~*
-app-emacs/emacs-common-gentoo	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/eudev
+++ b/profiles/targets/genpi64/package.accept_keywords/eudev
@@ -1,1 +1,0 @@
-sys-fs/eudev * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/euses
+++ b/profiles/targets/genpi64/package.accept_keywords/euses
@@ -1,1 +1,0 @@
-app-portage/euses * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/f2fs-tools
+++ b/profiles/targets/genpi64/package.accept_keywords/f2fs-tools
@@ -1,1 +1,0 @@
-sys-fs/f2fs-tools * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/fail2ban
+++ b/profiles/targets/genpi64/package.accept_keywords/fail2ban
@@ -1,1 +1,0 @@
-net-analyzer/fail2ban * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/firejail
+++ b/profiles/targets/genpi64/package.accept_keywords/firejail
@@ -1,1 +1,0 @@
-sys-apps/firejail * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/gegl
+++ b/profiles/targets/genpi64/package.accept_keywords/gegl
@@ -1,3 +1,0 @@
-# requirements of gegl
-media-libs/libnsgif * ~*
-

--- a/profiles/targets/genpi64/package.accept_keywords/i2c-tools
+++ b/profiles/targets/genpi64/package.accept_keywords/i2c-tools
@@ -1,2 +1,0 @@
-# https://bugs.gentoo.org/815802
-sys-apps/i2c-tools ~arm64

--- a/profiles/targets/genpi64/package.accept_keywords/iftop
+++ b/profiles/targets/genpi64/package.accept_keywords/iftop
@@ -1,2 +1,0 @@
-net-analyzer/iftop *
-

--- a/profiles/targets/genpi64/package.accept_keywords/iotop
+++ b/profiles/targets/genpi64/package.accept_keywords/iotop
@@ -1,1 +1,0 @@
-sys-process/iotop	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/iperf
+++ b/profiles/targets/genpi64/package.accept_keywords/iperf
@@ -1,1 +1,0 @@
-net-misc/iperf	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/iptraf-ng
+++ b/profiles/targets/genpi64/package.accept_keywords/iptraf-ng
@@ -1,1 +1,0 @@
-net-analyzer/iptraf-ng	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/iw
+++ b/profiles/targets/genpi64/package.accept_keywords/iw
@@ -1,1 +1,0 @@
-net-wireless/iw * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/jna
+++ b/profiles/targets/genpi64/package.accept_keywords/jna
@@ -1,2 +1,0 @@
-dev-java/jna * ~*
-

--- a/profiles/targets/genpi64/package.accept_keywords/libu2f-host
+++ b/profiles/targets/genpi64/package.accept_keywords/libu2f-host
@@ -1,1 +1,0 @@
-app-crypt/libu2f-host * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/links
+++ b/profiles/targets/genpi64/package.accept_keywords/links
@@ -1,1 +1,0 @@
-www-client/links	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/mailx
+++ b/profiles/targets/genpi64/package.accept_keywords/mailx
@@ -1,4 +1,0 @@
-mail-client/mailx       * ~*
-# required by mail-client/mailx
-mail-client/mailx-support       * ~*
-

--- a/profiles/targets/genpi64/package.accept_keywords/maven-bin
+++ b/profiles/targets/genpi64/package.accept_keywords/maven-bin
@@ -1,1 +1,0 @@
-dev-java/maven-bin * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/mc
+++ b/profiles/targets/genpi64/package.accept_keywords/mc
@@ -1,1 +1,0 @@
-app-misc/mc * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/mirrorselect
+++ b/profiles/targets/genpi64/package.accept_keywords/mirrorselect
@@ -1,3 +1,0 @@
-app-portage/mirrorselect * ~*
-# requirements of mirrorselect
-net-analyzer/netselect * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/mongodb
+++ b/profiles/targets/genpi64/package.accept_keywords/mongodb
@@ -1,4 +1,0 @@
-dev-db/mongodb * ~*
-# dependencies of mongodb
-app-admin/mongo-tools * ~*
-dev-python/cheetah3 * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/mpc
+++ b/profiles/targets/genpi64/package.accept_keywords/mpc
@@ -1,2 +1,0 @@
-media-sound/mpc * ~*
-media-libs/libmpdclient * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/mpd
+++ b/profiles/targets/genpi64/package.accept_keywords/mpd
@@ -1,1 +1,0 @@
-media-sound/mpd * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/multipath-tools
+++ b/profiles/targets/genpi64/package.accept_keywords/multipath-tools
@@ -1,2 +1,0 @@
-# dependencies of sys-fs/multipath-tools
-dev-libs/userspace-rcu	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/nasm
+++ b/profiles/targets/genpi64/package.accept_keywords/nasm
@@ -1,1 +1,0 @@
-dev-lang/nasm * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/networkmanager-openvpn
+++ b/profiles/targets/genpi64/package.accept_keywords/networkmanager-openvpn
@@ -1,9 +1,0 @@
-net-misc/networkmanager-openvpn	* ~*
-# the package has moved category; cover new location
-net-vpn/networkmanager-openvpn * ~*
-# dependencies of net-misc/networkmanager-openvpn
-net-libs/libqmi	* ~*
-net-misc/modemmanager	* ~*
-sys-auth/consolekit	* ~*
-gnome-extra/nm-applet	* ~*
-net-libs/libmbim	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/nullmailer
+++ b/profiles/targets/genpi64/package.accept_keywords/nullmailer
@@ -1,1 +1,0 @@
-mail-mta/nullmailer	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/openvpn
+++ b/profiles/targets/genpi64/package.accept_keywords/openvpn
@@ -1,2 +1,0 @@
-net-vpn/openvpn	* ~*
-

--- a/profiles/targets/genpi64/package.accept_keywords/p7zip
+++ b/profiles/targets/genpi64/package.accept_keywords/p7zip
@@ -1,4 +1,0 @@
-app-arch/p7zip	* ~*
-# dependencies of app-arch/p7zip
-x11-libs/wxGTK	* ~*
-app-eselect/eselect-wxwidgets	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/pecl-yaml
+++ b/profiles/targets/genpi64/package.accept_keywords/pecl-yaml
@@ -1,1 +1,0 @@
-dev-php/pecl-yaml * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/prosody
+++ b/profiles/targets/genpi64/package.accept_keywords/prosody
@@ -1,5 +1,0 @@
-net-im/prosody * ~*
-# dependencies of prosody
-net-im/jabber-base * ~*
-dev-lua/luasec * ~*
-dev-lua/lua-zlib * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/psutils
+++ b/profiles/targets/genpi64/package.accept_keywords/psutils
@@ -1,1 +1,0 @@
-app-text/psutils	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/rng-tools
+++ b/profiles/targets/genpi64/package.accept_keywords/rng-tools
@@ -1,1 +1,0 @@
-sys-apps/rng-tools * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/seahorse
+++ b/profiles/targets/genpi64/package.accept_keywords/seahorse
@@ -1,1 +1,0 @@
-app-crypt/seahorse	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/shed
+++ b/profiles/targets/genpi64/package.accept_keywords/shed
@@ -1,2 +1,0 @@
-app-editors/shed * ~*
-

--- a/profiles/targets/genpi64/package.accept_keywords/sipcalc
+++ b/profiles/targets/genpi64/package.accept_keywords/sipcalc
@@ -1,1 +1,0 @@
-net-misc/sipcalc * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/smartmontools
+++ b/profiles/targets/genpi64/package.accept_keywords/smartmontools
@@ -1,1 +1,0 @@
-sys-apps/smartmontools	* ~*

--- a/profiles/targets/genpi64/package.accept_keywords/sshguard
+++ b/profiles/targets/genpi64/package.accept_keywords/sshguard
@@ -1,1 +1,0 @@
-app-admin/sshguard * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/v4l-utils
+++ b/profiles/targets/genpi64/package.accept_keywords/v4l-utils
@@ -1,1 +1,0 @@
-media-tv/v4l-utils * ~*

--- a/profiles/targets/genpi64/package.accept_keywords/virtual-cron
+++ b/profiles/targets/genpi64/package.accept_keywords/virtual-cron
@@ -1,2 +1,0 @@
-virtual/cron * ~*
-

--- a/profiles/targets/genpi64/package.accept_keywords/zerofree
+++ b/profiles/targets/genpi64/package.accept_keywords/zerofree
@@ -1,1 +1,0 @@
-sys-fs/zerofree	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/ack
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/ack
@@ -1,3 +1,0 @@
-sys-apps/ack	* ~*
-# dependencies of sys-apps/ack
-dev-perl/File-Next	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/aide
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/aide
@@ -1,1 +1,0 @@
-app-forensics/aide * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/appstream-glib
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/appstream-glib
@@ -1,4 +1,0 @@
-dev-libs/appstream-glib	*
-# dependencies of appstream-glib
-dev-util/appdata-tools	*
-

--- a/profiles/targets/genpi64Exp/package.accept_keywords/at
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/at
@@ -1,2 +1,0 @@
-# per andi4567, this is working on arm64
-sys-process/at * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/authbind
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/authbind
@@ -1,1 +1,0 @@
-app-admin/authbind * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/boinc
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/boinc
@@ -1,1 +1,0 @@
-sci-misc/boinc * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/chrony
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/chrony
@@ -1,1 +1,0 @@
-net-misc/chrony * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/coturn
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/coturn
@@ -1,1 +1,0 @@
-net-im/coturn * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/dav1d
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/dav1d
@@ -1,1 +1,0 @@
-media-libs/dav1d * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/dos2unix
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/dos2unix
@@ -1,1 +1,0 @@
-app-text/dos2unix	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/elogviewer
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/elogviewer
@@ -1,6 +1,0 @@
-app-portage/elogviewer * ~*
-# dependencies of app-portage/elogviewer
-dev-python/PyQt5	* ~*
-dev-python/sip	* ~*
-dev-vcs/mercurial	* ~*
-dev-qt/qtbluetooth	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/emacs
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/emacs
@@ -1,5 +1,0 @@
-virtual/emacs	* ~*
-# dependencies of virtual/emacs
-app-editors/emacs	* ~*
-app-eselect/eselect-emacs	* ~*
-app-emacs/emacs-common-gentoo	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/eudev
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/eudev
@@ -1,1 +1,0 @@
-sys-fs/eudev * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/euses
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/euses
@@ -1,1 +1,0 @@
-app-portage/euses * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/f2fs-tools
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/f2fs-tools
@@ -1,1 +1,0 @@
-sys-fs/f2fs-tools * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/fail2ban
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/fail2ban
@@ -1,1 +1,0 @@
-net-analyzer/fail2ban * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/firejail
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/firejail
@@ -1,1 +1,0 @@
-sys-apps/firejail * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/gegl
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/gegl
@@ -1,3 +1,0 @@
-# requirements of gegl
-media-libs/libnsgif * ~*
-

--- a/profiles/targets/genpi64Exp/package.accept_keywords/iftop
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/iftop
@@ -1,2 +1,0 @@
-net-analyzer/iftop *
-

--- a/profiles/targets/genpi64Exp/package.accept_keywords/iotop
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/iotop
@@ -1,1 +1,0 @@
-sys-process/iotop	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/iperf
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/iperf
@@ -1,1 +1,0 @@
-net-misc/iperf	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/iptraf-ng
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/iptraf-ng
@@ -1,1 +1,0 @@
-net-analyzer/iptraf-ng	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/iw
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/iw
@@ -1,1 +1,0 @@
-net-wireless/iw * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/jna
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/jna
@@ -1,2 +1,0 @@
-dev-java/jna * ~*
-

--- a/profiles/targets/genpi64Exp/package.accept_keywords/libu2f-host
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/libu2f-host
@@ -1,1 +1,0 @@
-app-crypt/libu2f-host * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/links
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/links
@@ -1,1 +1,0 @@
-www-client/links	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/mailx
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/mailx
@@ -1,4 +1,0 @@
-mail-client/mailx       * ~*
-# required by mail-client/mailx
-mail-client/mailx-support       * ~*
-

--- a/profiles/targets/genpi64Exp/package.accept_keywords/maven-bin
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/maven-bin
@@ -1,1 +1,0 @@
-dev-java/maven-bin * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/mc
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/mc
@@ -1,1 +1,0 @@
-app-misc/mc * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/mirrorselect
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/mirrorselect
@@ -1,3 +1,0 @@
-app-portage/mirrorselect * ~*
-# requirements of mirrorselect
-net-analyzer/netselect * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/mongodb
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/mongodb
@@ -1,4 +1,0 @@
-dev-db/mongodb * ~*
-# dependencies of mongodb
-app-admin/mongo-tools * ~*
-dev-python/cheetah3 * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/mpc
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/mpc
@@ -1,2 +1,0 @@
-media-sound/mpc * ~*
-media-libs/libmpdclient * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/mpd
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/mpd
@@ -1,1 +1,0 @@
-media-sound/mpd * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/multipath-tools
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/multipath-tools
@@ -1,2 +1,0 @@
-# dependencies of sys-fs/multipath-tools
-dev-libs/userspace-rcu	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/nasm
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/nasm
@@ -1,1 +1,0 @@
-dev-lang/nasm * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/networkmanager-openvpn
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/networkmanager-openvpn
@@ -1,9 +1,0 @@
-net-misc/networkmanager-openvpn	* ~*
-# the package has moved category; cover new location
-net-vpn/networkmanager-openvpn * ~*
-# dependencies of net-misc/networkmanager-openvpn
-net-libs/libqmi	* ~*
-net-misc/modemmanager	* ~*
-sys-auth/consolekit	* ~*
-gnome-extra/nm-applet	* ~*
-net-libs/libmbim	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/nullmailer
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/nullmailer
@@ -1,1 +1,0 @@
-mail-mta/nullmailer	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/openvpn
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/openvpn
@@ -1,2 +1,0 @@
-net-vpn/openvpn	* ~*
-

--- a/profiles/targets/genpi64Exp/package.accept_keywords/p7zip
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/p7zip
@@ -1,4 +1,0 @@
-app-arch/p7zip	* ~*
-# dependencies of app-arch/p7zip
-x11-libs/wxGTK	* ~*
-app-eselect/eselect-wxwidgets	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/pecl-yaml
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/pecl-yaml
@@ -1,1 +1,0 @@
-dev-php/pecl-yaml * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/prosody
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/prosody
@@ -1,5 +1,0 @@
-net-im/prosody * ~*
-# dependencies of prosody
-net-im/jabber-base * ~*
-dev-lua/luasec * ~*
-dev-lua/lua-zlib * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/psutils
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/psutils
@@ -1,1 +1,0 @@
-app-text/psutils	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/rng-tools
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/rng-tools
@@ -1,1 +1,0 @@
-sys-apps/rng-tools * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/seahorse
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/seahorse
@@ -1,1 +1,0 @@
-app-crypt/seahorse	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/shed
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/shed
@@ -1,2 +1,0 @@
-app-editors/shed * ~*
-

--- a/profiles/targets/genpi64Exp/package.accept_keywords/sipcalc
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/sipcalc
@@ -1,1 +1,0 @@
-net-misc/sipcalc * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/smartmontools
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/smartmontools
@@ -1,1 +1,0 @@
-sys-apps/smartmontools	* ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/sshguard
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/sshguard
@@ -1,1 +1,0 @@
-app-admin/sshguard * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/v4l-utils
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/v4l-utils
@@ -1,1 +1,0 @@
-media-tv/v4l-utils * ~*

--- a/profiles/targets/genpi64Exp/package.accept_keywords/virtual-cron
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/virtual-cron
@@ -1,2 +1,0 @@
-virtual/cron * ~*
-

--- a/profiles/targets/genpi64Exp/package.accept_keywords/zerofree
+++ b/profiles/targets/genpi64Exp/package.accept_keywords/zerofree
@@ -1,1 +1,0 @@
-sys-fs/zerofree	* ~*


### PR DESCRIPTION
Remove package.accept_keywords for packages that are either already stable in gentoo, or not in our overlay or directly used by our packages