### PR TITLE
Update systemd profile packages

### DIFF
--- a/profiles/targets/systemd/packages
+++ b/profiles/targets/systemd/packages
@@ -1,1 +1,4 @@
 sys-block/zram-init
+net-dns/bind-tools
+net-analyzer/mtr
+net-misc/iperf


### PR DESCRIPTION
It feels quite wierd to not have dig, mtr or iperf by default.
