### PR TITLE
Remove x11-misc/rpi3-safecursor

### DIFF
--- a/profiles/targets/genpi64desktop/packages
+++ b/profiles/targets/genpi64desktop/packages
@@ -1,5 +1,4 @@
 x11-misc/rpi3-safecompositor
-x11-misc/rpi3-safecursor
 xfce-base/xfce4-meta
 dev-util/geany
 x11-base/xorg-server


### PR DESCRIPTION
Remove x11-misc/rpi3-safecursor from this list, it was delete with commit #93

#### Description
x11-misc/rpi3-safecursor was delete from the overlay, it should be removed from the packages list.


#### Issues Fixed or Closed by this PR

* 
