### PR TITLE
discussion: Allow elogind to use polkit

### DIFF
--- a/profiles/targets/genpi64/package.use/elogind
+++ b/profiles/targets/genpi64/package.use/elogind
@@ -1,1 +1,0 @@
-sys-auth/elogind -policykit


### PR DESCRIPTION
Now that gentoo upstream's polkit has ductape instead of spidermonkey (and therefore, doesn't use rust), why disable polkit for elogind?

Note that I don't use openrc, so I legitimately don't know what would motivate someone not to use polkit with elogind, if not the rust dependency.

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
