### PR TITLE
Don't specify QEMU settings

### DIFF
--- a/profiles/targets/genpi64/make.defaults
+++ b/profiles/targets/genpi64/make.defaults
@@ -31,10 +31,6 @@ FEATURES="userfetch -pid-sandbox"
 # Please keep this setting intact when reporting bugs.
 LC_MESSAGES=C
 
-# Default build targets for QEMU; override if desired.
-QEMU_SOFTMMU_TARGETS="aarch64 arm i386 x86_64"
-QEMU_USER_TARGETS="aarch64"
-
 # English L10N (for libreoffice spellcheck etc.)
 # Override if desired
 L10N="en en-US"


### PR DESCRIPTION
We have no reason to specify the emulation targets for qemu in the genpi64 profile. Our project only ever uses the host qemu to do anything.

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
