### PR TITLE
Don't set USE="-mudflap -sanitize" on desktop profile

### DIFF
--- a/profiles/targets/genpi64desktop/make.defaults
+++ b/profiles/targets/genpi64desktop/make.defaults
@@ -1,3 +1,3 @@
 # Additional USE flags in addition to those specified by the current profile.
-USE="bindist -mudflap -sanitize X gtk3 qt5"
+USE="bindist X gtk3 qt5"
 


### PR DESCRIPTION
As with https://github.com/GenPi64/genpi64-overlay/pull/119 , sanitize should be left to default.
The mudflap flag is no longer available in newer gcc (superseded by sanitize, i believe. I think gcc removed mudflap as a library back in 2012?)

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
