### PR TITLE
delete package.mask/sdl2 , obsolete

### DIFF
--- a/profiles/targets/genpi64/package.mask/sdl2
+++ b/profiles/targets/genpi64/package.mask/sdl2
@@ -1,2 +1,0 @@
-<media-libs/libsdl2-2.0.14-r1
-media-libs/libsdl2:gentoo


### PR DESCRIPTION
The masked versions of sdl2 are no longer in the gentoo tree.

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
