### PR TITLE
Delete package.use/qemu

### DIFF
--- a/profiles/targets/genpi64/package.use/qemu
+++ b/profiles/targets/genpi64/package.use/qemu
@@ -1,1 +1,0 @@
-app-emulation/qemu spice vhost-net virtfs xattr usbredir alsa fdt


### PR DESCRIPTION
We have no need to provide default values for qemu, we don't use it on the image, only on the host machine.
Users can, and should, specify their own settings.

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
