### PR TITLE
Don't specify default use flags for php

### DIFF
--- a/profiles/targets/genpi64/package.use/php
+++ b/profiles/targets/genpi64/package.use/php
@@ -1,4 +1,0 @@
-# build some generally useful options for php
->=dev-lang/php-7.2 bcmath curl sockets threads zip
->=dev-lang/php-7.2.16 sqlite
->=dev-lang/php-7.2.16 mysqli


### PR DESCRIPTION
Nothing in our project touches php.

End users can specify these flags if they want.

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
