### PR TITLE
delete package.use/llvm, unneeded

### DIFF
--- a/profiles/targets/genpi64/package.use/llvm
+++ b/profiles/targets/genpi64/package.use/llvm
@@ -1,2 +1,0 @@
-# enable gold linker, neccessary to build e.g. firefox
->=sys-devel/llvm-7.0.0 gold


### PR DESCRIPTION
Latest stable aarch64 llvm is 13, which does not have the gold useflag.

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
