### PR TITLE
Delete package.use/PyQt5

### DIFF
--- a/profiles/targets/genpi64/package.use/PyQt5
+++ b/profiles/targets/genpi64/package.use/PyQt5
@@ -1,1 +1,0 @@
-dev-python/PyQt5 designer examples


### PR DESCRIPTION
Based on grepping the gentoo and genpi64 overlays, i don't see any dependencies that we use that need PyQt5 to have these use flags.
```
grep -I -e "PyQt5\[.*designer.*\]" -r /var/db/repos/ | grep -v metadata
/var/db/repos/gentoo/dev-python/QtPy/QtPy-2.0.1.ebuild:	dev-python/PyQt5[declarative?,designer?,gui?,help?,location?]
/var/db/repos/gentoo/dev-python/QtPy/QtPy-2.0.1.ebuild:	        dev-python/PyQt5[bluetooth,dbus,declarative,designer,gui,help,location]
/var/db/repos/gentoo/dev-python/QtPy/QtPy-2.1.0.ebuild:	dev-python/PyQt5[declarative?,designer?,gui?,help?,location?]
/var/db/repos/gentoo/dev-python/QtPy/QtPy-2.1.0.ebuild:	        dev-python/PyQt5[bluetooth,dbus,declarative,designer,gui,help,location]
/var/db/repos/gentoo/sci-geosciences/qgis/qgis-3.22.0-r4.ebuild:		                dev-python/PyQt5[designer,gui,network,positioning,printsupport,sql,svg,widgets,${PYTHON_USEDEP}]
/var/db/repos/gentoo/sci-geosciences/qgis/qgis-3.22.6.ebuild:		                dev-python/PyQt5[designer,gui,network,positioning,printsupport,sql,svg,widgets,${PYTHON_USEDEP}]
/var/db/repos/gentoo/sci-geosciences/qgis/qgis-3.22.7.ebuild:		                dev-python/PyQt5[designer,gui,network,positioning,printsupport,sql,svg,widgets,${PYTHON_USEDEP}]
/var/db/repos/gentoo/sci-geosciences/qgis/qgis-9999.ebuild:		                dev-python/PyQt5[designer,gui,network,positioning,printsupport,sql,svg,widgets,${PYTHON_USEDEP}]
/var/db/repos/gentoo/sci-geosciences/qgis/qgis-3.22.5.ebuild:		                dev-python/PyQt5[designer,gui,network,positioning,printsupport,sql,svg,widgets,${PYTHON_USEDEP}]
```
and searching for QtPy turns up nothing.
```
grep -I -e "QtPy\[.*designer.*\]" -r /var/db/repos/ | grep -v metadata
```

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
