### PR TITLE
Remove linux-firmware from package.usr/brcm43430-firmware

### DIFF
--- a/profiles/targets/genpi64/package.use/brcm43430-firmware
+++ b/profiles/targets/genpi64/package.use/brcm43430-firmware
@@ -1,4 +1,2 @@
 # use Raspbian's version of the uploadable RPi4 WiFi chip driver
 >=sys-firmware/brcm43430-firmware-20190812-r1 43455-fix
-# deps of brcm43430-firmware
->=sys-kernel/linux-firmware-20191108-r1 43455-fix


### PR DESCRIPTION
No available versions of the linux-firmware package have the use flag listed.

I haven't yet evaluated if the brcm43430-firmware package could be improved

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
