### PR TITLE
delete package.use/hplip

### DIFF
--- a/profiles/targets/genpi64/package.use/hplip
+++ b/profiles/targets/genpi64/package.use/hplip
@@ -1,2 +1,0 @@
-# some fairly common models won't work without the following USE
->=net-print/hplip-3.20.6-r1 static-ppds


### PR DESCRIPTION
While this is an interesting backwards compatibility setting for users who have this printer, it really has nothing to do with genpi64, and end-users can set it themselves if they want.

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
