### PR TITLE
Remove package.use/polkit

### DIFF
--- a/profiles/targets/genpi64/package.use/polkit
+++ b/profiles/targets/genpi64/package.use/polkit
@@ -1,1 +1,0 @@
-sys-auth/polkit duktape


### PR DESCRIPTION
duktape is now the default setting with upstream gentoo. We no longer need to specify this ourselves.

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
