### PR TITLE
Delete forced setting of python_3_9 in profile

### DIFF
--- a/profiles/targets/genpi64/package.use/python_3_9
+++ b/profiles/targets/genpi64/package.use/python_3_9
@@ -1,4 +1,0 @@
->=dev-python/setuptools-51.0.0 python_targets_python3_9
-=dev-python/certifi-10001-r1 python_targets_python3_9
->=dev-python/setuptools_scm-5.0.1 python_targets_python3_9
-


### PR DESCRIPTION
Prevents updates against newest upstream gentoo portage tree.

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
