### PR TITLE
Update accept_keywords for micropython

### DIFF
--- a/profiles/targets/genpi64/package.accept_keywords/micropython
+++ b/profiles/targets/genpi64/package.accept_keywords/micropython
@@ -1,1 +1,1 @@
-=dev-lang/micropython-1.11-r1 **
+dev-lang/micropython **

--- a/profiles/targets/genpi64/package.accept_keywords/micropython
+++ b/profiles/targets/genpi64/package.accept_keywords/micropython
@@ -1,1 +1,1 @@
-dev-lang/micropython **
+dev-lang/micropython ~*


### PR DESCRIPTION
It shouldn't be for just a specific version.
