### PR TITLE
New onboard ebuild 

### DIFF
--- a/app-accessibility/onboard/onboard-1.4.1-r2.ebuild
+++ b/app-accessibility/onboard/onboard-1.4.1-r2.ebuild
@@ -11,17 +11,17 @@ inherit distutils-r1 gnome2-utils
 
 DESCRIPTION="An onscreen keyboard useful for tablet PC users and for mobility impaired users"
 HOMEPAGE="https://launchpad.net/onboard"
-# Ojo Staba Mal
-#SRC_URI="https://github.com/linuxdeepin/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
-SRC_URI="https://launchpad.net/${PN}/$(ver_cut 1-2)/${PV}/+download/${P}.tar.gz"
+# Using of PN variable avoided, Following note in
+# https://wiki.gentoo.org/wiki/Basic_guide_to_write_Gentoo_Ebuilds
+SRC_URI="https://launchpad.net/onboard/$(ver_cut 1-2)/${PV}/+download/${P}.tar.gz"
 
 # po/* are licensed under BSD 3-clause
 LICENSE="GPL-3+ BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~x86"
+KEYWORDS="~amd64 arm arm64 ~x86"
 
 COMMON_DEPEND="app-text/hunspell:=
-	dev-libs/dbus-glib
+	dev-libs/dbus-glib these deps,
 	dev-python/dbus-python[${PYTHON_USEDEP}]
 	dev-python/pycairo[${PYTHON_USEDEP}]
 	dev-python/pygobject:3[${PYTHON_USEDEP}]
@@ -46,15 +46,10 @@ RDEPEND="${COMMON_DEPEND}
 	gnome-extra/mousetweaks
 	x11-libs/libxkbfile"
 
-RESTRICT="mirror"
-
-src_prepare() {
-	distutils-r1_src_prepare
-	eapply_user
-}
-
 src_install() {
 	distutils-r1_src_install
+	# Delete duplicated docs installed by original dustutils
+	rm "${D}"/usr/share/doc/onboard/*
 }
 
 pkg_preinst() {

--- a/app-accessibility/onboard/onboard-1.4.1-r2.ebuild
+++ b/app-accessibility/onboard/onboard-1.4.1-r2.ebuild
@@ -1,0 +1,75 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DISTUTILS_USE_SETUPTOOLS="no"
+
+PYTHON_COMPAT=( python3_{8,9,10,11} )
+
+inherit distutils-r1 gnome2-utils
+
+DESCRIPTION="An onscreen keyboard useful for tablet PC users and for mobility impaired users"
+HOMEPAGE="https://launchpad.net/onboard"
+# Ojo Staba Mal
+#SRC_URI="https://github.com/linuxdeepin/${PN}/archive/${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="https://launchpad.net/${PN}/$(ver_cut 1-2)/${PV}/+download/${P}.tar.gz"
+
+# po/* are licensed under BSD 3-clause
+LICENSE="GPL-3+ BSD"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64 ~x86"
+
+COMMON_DEPEND="app-text/hunspell:=
+	dev-libs/dbus-glib
+	dev-python/dbus-python[${PYTHON_USEDEP}]
+	dev-python/pycairo[${PYTHON_USEDEP}]
+	dev-python/pygobject:3[${PYTHON_USEDEP}]
+	dev-python/python-distutils-extra[${PYTHON_USEDEP}]
+	gnome-base/dconf
+	gnome-base/gsettings-desktop-schemas
+	gnome-base/librsvg
+	media-libs/libcanberra
+	sys-apps/dbus
+	x11-libs/gdk-pixbuf
+	x11-libs/gtk+:3[introspection]
+	x11-libs/libX11
+	x11-libs/libXi
+	x11-libs/libXtst
+	x11-libs/libwnck:3
+	x11-libs/pango"
+DEPEND="${COMMON_DEPEND}
+	dev-util/intltool"
+RDEPEND="${COMMON_DEPEND}
+	app-accessibility/at-spi2-core
+	app-text/iso-codes
+	gnome-extra/mousetweaks
+	x11-libs/libxkbfile"
+
+RESTRICT="mirror"
+
+src_prepare() {
+	distutils-r1_src_prepare
+	eapply_user
+}
+
+src_install() {
+	distutils-r1_src_install
+}
+
+pkg_preinst() {
+	gnome2_icon_savelist
+	gnome2_schemas_savelist
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	gnome2_schemas_update
+	xdg_desktop_database_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	gnome2_schemas_update
+	xdg_desktop_database_update
+}


### PR DESCRIPTION
#### Description
Adding a working onboard ebuild -r2 as advised by jonesmz in Discord
#### Issues Fixed or Closed by this PR
it is an alternative for the currently failing onboard-1.4.1-r1. ebuild that issues message:

ERROR: app-accessibility/onboard-1.4.1-r1::genpi64 failed (depend phase):
 \ *   No supported implementation in PYTHON_COMPAT...
