### PR TITLE
profiles/targets/genpi64/package.mask: Do not mask rust

### DIFF
--- a/profiles/targets/genpi64/package.mask/rust
+++ b/profiles/targets/genpi64/package.mask/rust
@@ -1,1 +1,0 @@
-dev-lang/rust


### PR DESCRIPTION
#### Description
Let's not mask rust anymore

It may not build easilly, but we shouldn't mask it I don't think.
