### PR TITLE
Remove non-desktop setting for notification-daemon

### DIFF
--- a/profiles/targets/genpi64/package.mask/notification-daemon
+++ b/profiles/targets/genpi64/package.mask/notification-daemon
@@ -1,2 +1,0 @@
-# force use of xfce-extra/xfce4-notifyd
-x11-misc/notification-daemon


### PR DESCRIPTION
This setting doesn't apply to the non-desktop profile. Lets remove it. Arguably, it's the users choice regardless.

#### Description
A few sentences describing the overall goals of the pull request's commits.


#### Issues Fixed or Closed by this PR

* 
