### PR TITLE
Update rpi-imager-1.7.3.ebuild

### DIFF
--- a/dev-embedded/rpi-imager/rpi-imager-1.7.3.ebuild
+++ b/dev-embedded/rpi-imager/rpi-imager-1.7.3.ebuild
@@ -20,5 +20,10 @@ SLOT="0"
 KEYWORDS="~arm64 ~amd64"
 IUSE=""
 
-DEPEND=""
-RDEPEND="${DEPEND}"
+DEPEND="
+        dev-qt/qtconcurrent
+        "
+        
+RDEPEND="
+        dev-qt/qtquickcontrols2
+        "


### PR DESCRIPTION
Included dependencies: 
dev-qt/qtconcurrent, required to compile. 
dev-qt/qtquickcontrols2, required at runtime.

