### PR TITLE
Pull over the acct-group/spi and acct-group/gpio from gentoo

### DIFF
--- a/acct-group/gpio/gpio-0-r1.ebuild
+++ b/acct-group/gpio/gpio-0-r1.ebuild
@@ -1,0 +1,8 @@
+# Copyright 2019-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+ACCT_GROUP_ID="225"

--- a/acct-group/gpio/metadata.xml
+++ b/acct-group/gpio/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person" proxied="yes">
+		<email>crabbedhaloablution@icloud.com</email>
+		<name>Peter Alfredsen</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-group/spi/metadata.xml
+++ b/acct-group/spi/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person" proxied="yes">
+		<email>crabbedhaloablution@icloud.com</email>
+		<name>Peter Alfredsen</name>
+	</maintainer>
+	<maintainer type="project" proxied="proxy">
+		<email>proxy-maint@gentoo.org</email>
+		<name>Proxy Maintainers</name>
+	</maintainer>
+</pkgmetadata>

--- a/acct-group/spi/spi-0-r1.ebuild
+++ b/acct-group/spi/spi-0-r1.ebuild
@@ -1,0 +1,8 @@
+# Copyright 2019-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+ACCT_GROUP_ID="227"

--- a/profiles/targets/genpi64/package.unmask/acct-group
+++ b/profiles/targets/genpi64/package.unmask/acct-group
@@ -1,0 +1,4 @@
+# Unmask the following two account ebuilds, gentoo masked them for removal, and broke us.
+# Can be removed after Aug 2023
+acct-group/spi
+acct-group/gpio


### PR DESCRIPTION
This fixes gentoo having masked the packages for removal...