### PR TITLE
Remove app-portage/showem from genpi64 profile.

### DIFF
--- a/profiles/targets/genpi64/packages
+++ b/profiles/targets/genpi64/packages
@@ -23,7 +23,6 @@ sys-apps/rng-tools
 net-wireless/rpi3-bluetooth
 sys-apps/rpi3-init-scripts
 sys-apps/rpi3-ondemand-cpufreq
-app-portage/showem
 dev-embedded/rpi-eeprom
 net-wireless/rpi3-wifi-regdom
 sys-apps/rpi-gpio


### PR DESCRIPTION
#### Description
eutils.eclass no longer exists. My 2c is that it shouldn't be in the profile because it is a non-standard tool that's not necessary for operating Gentoo on the raspberry pi.
