### PR TITLE
Replace deprecated repoman with pkgdev for manifest generation

### DIFF
--- a/.github/workflows/regenerate-manifest.yml
+++ b/.github/workflows/regenerate-manifest.yml
@@ -25,8 +25,8 @@ jobs:
           # Sync portage tree (minimal sync)
           emerge-webrsync || emerge --sync
 
-          # Install app-portage/repoman for manifest generation
-          emerge --quiet app-portage/repoman
+          # Install dev-util/pkgdev for manifest generation
+          emerge dev-util/pkgdev
 
       - name: Find modified ebuilds
         id: find-ebuilds
@@ -65,11 +65,14 @@ jobs:
               continue
             fi
 
-            # Generate manifest
-            ebuild "$EBUILD" manifest || {
+            # Get the package directory and generate manifest using pkgdev
+            EBUILD_DIR=$(dirname "$EBUILD")
+            cd "$EBUILD_DIR"
+            pkgdev manifest || {
               echo "Error: Failed to generate manifest for $EBUILD"
               exit 1
             }
+            cd "$GITHUB_WORKSPACE"
 
             echo "✓ Manifest generated for $EBUILD"
           done

--- a/regenerate-manifest.sh
+++ b/regenerate-manifest.sh
@@ -36,8 +36,8 @@ for EBUILD in $MODIFIED_EBUILDS; do
     # Get the directory containing the ebuild
     EBUILD_DIR=$(dirname "$EBUILD")
 
-    # Run ebuild manifest
-    if ebuild "$EBUILD" manifest; then
+    # Run pkgdev manifest
+    if (cd "$EBUILD_DIR" && pkgdev manifest); then
         echo "✓ Manifest generated for $EBUILD"
     else
         echo "✗ Failed to generate manifest for $EBUILD"


### PR DESCRIPTION
Update both the CI workflow and local script to use the modern pkgdev tool instead of the deprecated repoman for generating package manifests.

- Replace app-portage/repoman with dev-util/pkgdev
- Update manifest generation commands from 'ebuild manifest' to 'pkgdev manifest'

Assisted-by: Claude Sonnet 4.5 via Claude Code
